### PR TITLE
Update skpm/builder version to be able to use Sketch API

### DIFF
--- a/template/package.json
+++ b/template/package.json
@@ -19,7 +19,7 @@
     "prettify": "npm run prettier:base \"./src/**/*.js\""
   },
   "devDependencies": {
-    "@skpm/builder": "^0.1.3",
+    "@skpm/builder": "^0.4.2",
     "eslint": "^4.8.0",
     "eslint-config-airbnb-base": "^12.0.2",
     "eslint-config-prettier": "^2.6.0",


### PR DESCRIPTION
Based on this issue: https://github.com/skpm/skpm/issues/124

I've had the same problem trying to use this template with Sketch API and I just wanted to update this template to prevent people to struggle with this in the future